### PR TITLE
Accept 'quiet' option to disable progress bar

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ You **must** provide the following options:
 - `platform` - kind of OS (`darwin`, `linux`, `win32`)
 
 The following options are **optional**:
-
+- `quiet` - suppress a progress bar when downloading
 - `token` - GitHub access token(to avoid request limit. You can grab it [here](https://github.com/settings/tokens))
 
 - `arch` - the processor architecture (`ia32`, `x64`)

--- a/src/download.js
+++ b/src/download.js
@@ -80,7 +80,7 @@ function download(opts, cb) {
 			}
 
 			github.downloadAsset(asset, function (error, istream) {
-				if (process.stdout.isTTY) {
+				if (process.stdout.isTTY && !opts.quiet) {
 					var bar = new ProgressBar('↓ ' + asset.name + ' [:bar] :percent', {
 						total: asset.size,
 						width: 20
@@ -110,7 +110,8 @@ module.exports = function (opts) {
 		version: opts.version,
 		platform: opts.platform,
 		arch: opts.arch,
-		token: opts.token
+		token: opts.token,
+		quiet: opts.quiet
 	}, function(err, vanilla) {
 		if (err) { return stream.emit('error', err); }
 		zfs.src(vanilla).pipe(stream);


### PR DESCRIPTION
I'm using gulp-atom-electron with Travis CI's Deployments feature to compile binaries. Since Travis is emulating a TTY, gulp-atom-electron displays a progress bar, but since Travis isn't providing a real TTY, the progress bar can't be properly displayed, and instead I see [this](https://travis-ci.org/mathphreak/ReliefValve/jobs/105940127#L467). With this patch, I can pass `quiet: true` and have more useful CI output.