### PR TITLE
Run rcedit outside win32 if Wine is available

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,8 @@
     "semver": "^4.3.4",
     "temp": "^0.8.1",
     "vinyl": "^0.5.1",
-    "vinyl-fs": "^0.3.13"
+    "vinyl-fs": "^0.3.13",
+    "which": "1.2.4"
   },
   "devDependencies": {
     "mocha": "^2.0.1"

--- a/src/win32.js
+++ b/src/win32.js
@@ -7,6 +7,7 @@ var rename = require('gulp-rename');
 var temp = require('temp').track();
 var rcedit = require('rcedit');
 var semver = require('semver');
+var which = require('which');
 var util = require('./util');
 
 function getOriginalAppName(opts) {
@@ -23,8 +24,22 @@ exports.getAppPath = function(opts) {
 
 function patchExecutable(opts) {
 	return es.map(function (f, cb) {
-		if (f.relative !== getOriginalAppFullName(opts) || process.platform !== 'win32') {
+		if (f.relative !== getOriginalAppFullName(opts)) {
 			return cb(null, f);
+		}
+
+		if (process.platform !== 'win32') {
+			// check for Wine in path
+			var winePath;
+			try {
+				which.sync('wine'); // returns path if found, throws if not
+			} catch (e) {
+				// Wine is not in path
+				return cb(null, f);
+			}
+
+			// if we got here, we kniw Wine is in the path
+			// and so we want to run rcedit despite not being on Win32
 		}
 
 		var patch = {


### PR DESCRIPTION
Since rcedit automatically uses Wine if it is necessary, simply checking if Wine is available is enough to go ahead and run rcedit.
