### PR TITLE
Correctly triggering rcedit on stream close

### DIFF
--- a/src/win32.js
+++ b/src/win32.js
@@ -47,7 +47,7 @@ function patchExecutable(opts) {
 		var ostream = fs.createWriteStream(tempPath);
 
 		f.contents.pipe(ostream);
-		ostream.on('finish', function () {
+		ostream.on('close', function () {
 			rcedit(tempPath, patch, function (err) {
 				if (err) { return cb(err); }
 


### PR DESCRIPTION
On windows finish is called prior to closing the stream, this causes problems if the system does not close the file fast enough: rcedit will not be able to access the file because it is already open. Triggering rcedit on stream closure fixes this.

This PR fixes issue #37.