### PR TITLE
MacOS Help Book Registration

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ The following options are **optional**:
 
 - **Darwin**
 	- `darwinIcon` - path to an `.icns` file
+	- `darwinHelpBookFolder` - the `CFBundleHelpBookFolder` value
+	- `darwinHelpBookName` - the `CFBundleHelpBookName` value
 	- `darwinBundleDocumentTypes` - ([reference](https://developer.apple.com/library/ios/documentation/filemanagement/conceptual/documentinteraction_topicsforios/Articles/RegisteringtheFileTypesYourAppSupports.html)) array of dictionaries, each containing the following structure:
 	 - `name` - the `CFBundleTypeName` value
 	 - `role` - the `CFBundleTypeRole` value

--- a/src/darwin.js
+++ b/src/darwin.js
@@ -87,6 +87,12 @@ function patchInfoPlist(opts) {
 			opts.copyright && (infoPlist['NSHumanReadableCopyright'] = opts.copyright);
 			infoPlist['CFBundleIconFile'] = opts.productName + '.icns';
 
+			//Register the Application Help Book if it exists
+			if (opts.darwinHelpBookFolder && opts.darwinHelpBookName){
+				infoPlist['CFBundleHelpBookFolder'] = opts.darwinHelpBookFolder;
+				infoPlist['CFBundleHelpBookName'] = opts.darwinHelpBookName;
+			}
+
 			if (opts.darwinBundleDocumentTypes) {
 				var iconsPaths = [];
 


### PR DESCRIPTION
Adds the ability to [register MacOS Help Books](https://developer.apple.com/library/content/documentation/Carbon/Conceptual/ProvidingUserAssitAppleHelp/registering_help/registering_help.html) via the options darwinHelpBookFolder and darwinHelpBookName.

Fixes [Microsoft/vscode#18697](https://github.com/Microsoft/vscode/issues/18697).

Simply adding a Help Book reference (exitstent or not) will prevent the MacOS help topics from displaying and solve the above issue (see iTerm2 and Finder examples below).

<img width="809" alt="screen shot 2017-05-29 at 10 36 19 pm" src="https://cloud.githubusercontent.com/assets/20881794/26566483/91bbe970-44c1-11e7-8868-065a0d32277d.png">
<img width="707" alt="screen shot 2017-05-29 at 10 36 06 pm" src="https://cloud.githubusercontent.com/assets/20881794/26566484/91c71246-44c1-11e7-8a55-282854bfcad3.png">
<img width="385" alt="screen shot 2017-05-29 at 10 28 49 pm" src="https://cloud.githubusercontent.com/assets/20881794/26566704/55ac2d80-44c3-11e7-94d7-5e09037d68f4.png">
<img width="262" alt="screen shot 2017-05-29 at 10 33 37 pm" src="https://cloud.githubusercontent.com/assets/20881794/26566705/55b563aa-44c3-11e7-8556-0270892f7708.png">