### PR TITLE
Update github-releases's version to ^0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/joaomoreno/gulp-atom-electron",
   "dependencies": {
     "event-stream": "^3.1.7",
-    "github-releases": "^0.2.0",
+    "github-releases": "^0.4.0",
     "gulp-filter": "^4.0.0",
     "gulp-rename": "^1.2.0",
     "gulp-symdest": "^1.0.0",


### PR DESCRIPTION
Considering **github-releases ^0.2.0** use a very old version **request**, **gulp-atom-electron** can't work using http proxy with ssl verification disabled.

Only **github-releases** version >= 0.4.0 use correct **request** version. 

But this version **github-releases** use ES2015 style that can't run on nodejs v0.10.