### PR TITLE
Update github-releases dependency

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: node_js
 node_js:
-  - "0.10"
+  - "lts/*"
+  - "node"
 sudo: false

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "homepage": "https://github.com/joaomoreno/gulp-atom-electron",
   "dependencies": {
     "event-stream": "^3.1.7",
-    "github-releases": "^0.2.0",
+    "github-releases": "^0.4.1",
     "gulp-filter": "^4.0.0",
     "gulp-rename": "^1.2.0",
     "gulp-symdest": "^1.0.0",


### PR DESCRIPTION
Hi! This updates `github-releases` to its latest release.

Primarily this is to pull in this fix: https://github.com/atom/node-github-releases/issues/2

For those of us behind an authenticated corporate proxy, this change is required download Electron.

This should also help alleviate (but not completely fix) #43, as the update to `request` seems to be more robust.