### PR TITLE
Add support for omitting the electron icon from darwin builds

### DIFF
--- a/src/darwin.js
+++ b/src/darwin.js
@@ -41,7 +41,8 @@ function patchIcon(opts) {
 	}
 
 	var resourcesPath = path.join(getOriginalAppFullName(opts), 'Contents', 'Resources');
-	var originalIconPath = path.join(resourcesPath, 'atom.icns');
+	var iconName = semver.gte(opts.version, '0.24.0') ? 'electron.icns' : 'atom.icns';
+	var originalIconPath = path.join(resourcesPath, iconName);
 	var iconPath = path.join(resourcesPath, opts.productName + '.icns');
 	var pass = es.through();
 


### PR DESCRIPTION
VSCode's macOS build currently contains two icon files in its application bundle:
<img width="713" alt="screen shot 2018-03-08 at 5 38 39 pm" src="https://user-images.githubusercontent.com/712727/37136882-8d9868d6-22f7-11e8-9e6d-d76a8d68454a.png">

The unnecessary `electron.icns` icon takes up a decent chunk of space, and I've confirmed with electron maintainer @MarshallOfSound that it should be replaced by the app's own icon. This PR does that by searching for `electron.icns` as well as the original `atom.icns` file when creating a list of items to filter. 

Thanks for the awesome work! ✨ 