### PR TITLE
feat: add darwinForceDarkModeSupport option to support mojave dark mode for older electron versions

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,7 @@ The following options are **optional**:
 		- `utis` - the `LSItemContentTypes` value, a `string` array
 		- `extensions` - the `CFBundleTypeExtensions` value, a `string` array of file extensions
 		- `iconFile` - the `CFBundleTypeIconFile` value
+	- `darwinForceDarkModeSupport` - Forces Mojave dark mode support to be enabled for older Electron versions
 
 - **Linux**
 	- `linuxExecutableName` - overwrite the name of the executable in Linux

--- a/src/darwin.js
+++ b/src/darwin.js
@@ -140,6 +140,10 @@ function patchInfoPlist(opts) {
 				})
 			}
 
+			if (opts.darwinForceDarkModeSupport) {
+				infoPlist['NSRequiresAquaSystemAppearance'] = false
+			}
+
 			f.contents = new Buffer(plist.build(infoPlist), 'utf8');
 			that.emit('data', f);
 		});


### PR DESCRIPTION
This will add the `NSRequiresAquaSystemAppearance=false` key value pair to the app's `Info.plist` to force dark mode support on Mojave.

cc @bpasero 

refs: https://github.com/Microsoft/vscode/pull/59742