### PR TITLE
Mapping "arm" to "armv7l" to match Electron naming

### DIFF
--- a/src/download.js
+++ b/src/download.js
@@ -132,7 +132,7 @@ module.exports = function (opts) {
 	var downloadOpts = {
 		version: opts.version,
 		platform: opts.platform,
-		arch: ( opts.arch == 'arm' ? 'armv7l' : opts.arch ),
+		arch: ( opts.arch === 'arm' ? 'armv7l' : opts.arch ),
 		assetName: semver.gte(opts.version, '0.24.0') ? 'electron' : 'atom-shell',
 		token: opts.token,
 		quiet: opts.quiet,

--- a/src/download.js
+++ b/src/download.js
@@ -132,7 +132,7 @@ module.exports = function (opts) {
 	var downloadOpts = {
 		version: opts.version,
 		platform: opts.platform,
-		arch: opts.arch,
+		arch: ( opts.arch == 'arm' ? 'armv7l' : opts.arch ),
 		assetName: semver.gte(opts.version, '0.24.0') ? 'electron' : 'atom-shell',
 		token: opts.token,
 		quiet: opts.quiet,


### PR DESCRIPTION
The module breaks when trying to build for ARM32 as it uses the old Electron naming convention of "arm".  Electron have changed their release package name to "armv7l" to distinguish it from ARM64 builds.  Unfortunately all of the VS Code scripts still refer to this as "arm" so it's breaking downstream builds irreparably (the scripts to build VS Code can't be run without hacking around this issue, and not in a CI environment).  This quickly patches the problem so that ARM32 builds work again (although I suspect you plan to abandon this module in future due to the readme saying it's deprecated?).